### PR TITLE
Fix closing tag in BitikTranslator component

### DIFF
--- a/src/components/BitikTranslator/index.tsx
+++ b/src/components/BitikTranslator/index.tsx
@@ -49,7 +49,7 @@ export const BitikTranslator: React.FC = () => {
 						border: '1px solid #ccc',
 					}}
 				/>
-			</ Box>
+                        </Box>
 			<div>
 				<div style={{fontSize: '2rem', marginTop: '0.5rem'}}>{output}</div>
 			</div>


### PR DESCRIPTION
## Summary
- fix malformed closing tag in BitikTranslator component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/BitikTranslator/index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895de1eb6608329949aafe8d45c1a34