### PR TITLE
feat: add responsive home page with navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,18 @@
-import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
-import PageQr from "./pages/PageQr.tsx";
-import {JSX} from "react";
-import BitikTranslate from "./pages/BitikTranslate.tsx";
-import {Button} from "@chakra-ui/react";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { JSX } from 'react';
+import PageQr from './pages/PageQr.tsx';
+import BitikTranslate from './pages/BitikTranslate.tsx';
+import HomePage from './pages/HomePage.tsx';
 
-function App() {
+function App(): JSX.Element {
   return (
-  <BrowserRouter>
-    <Routes>
-      <Route path="/qr/:id" element={<PageQr /> as JSX.Element} />
-      <Route path="*" element={<div>404</div>} />
-      <Route path="/" element={
-        <div>
-          Welcome to the QR Code App
-          <Navigate to={'/bitik'} replace>
-            <Button title='Переводчик в Битик' />
-          </Navigate>
-        </div>} />
-      <Route path="/bitik" element={<BitikTranslate />} />
-    </Routes>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/bitik" element={<BitikTranslate />} />
+        <Route path="/qr/:id" element={<PageQr /> as JSX.Element} />
+        <Route path="*" element={<div>404</div>} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,17 @@
+import { Box, Flex, Button, Stack, Heading } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+
+const Navbar = () => (
+  <Box as="nav" bg="purple.600" px={4} py={3} color="white">
+    <Flex align="center" justify="space-between" flexWrap="wrap">
+      <Heading size="md">Bitik</Heading>
+      <Stack direction={{ base: 'column', md: 'row' }} spacing={{ base: 2, md: 4 }} mt={{ base: 4, md: 0 }}>
+        <Button as={RouterLink} to="/" colorScheme="teal" variant="ghost">Главная</Button>
+        <Button as={RouterLink} to="/bitik" colorScheme="teal" variant="solid">Переводчик</Button>
+        <Button as={RouterLink} to="/qr/abc123" colorScheme="teal" variant="outline">QR пример</Button>
+      </Stack>
+    </Flex>
+  </Box>
+);
+
+export default Navbar;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,47 @@
+import { Box, Container, Heading, Text, SimpleGrid, Stack, Image } from '@chakra-ui/react';
+import Navbar from '../components/Navbar';
+import bg from '../assets/content/bg.png';
+import tshirt from '../assets/content/white_tshirt.png';
+
+const features = [
+  {
+    title: 'QR-метки',
+    description: 'Создавайте и делитесь уникальными QR-кодами.',
+    image: bg,
+  },
+  {
+    title: 'Переводчик Bitik',
+    description: 'Мгновенно переводите текст в уникальный шрифт.',
+    image: tshirt,
+  },
+  {
+    title: 'Адаптивный дизайн',
+    description: 'Интерфейс удобно выглядит на любом устройстве.',
+    image: 'https://via.placeholder.com/400',
+  },
+];
+
+export default function HomePage() {
+  return (
+    <Box>
+      <Navbar />
+      <Container maxW="container.xl" py={10}>
+        <Stack textAlign="center" spacing={6}>
+          <Heading size="2xl">Добро пожаловать в Bitik</Heading>
+          <Text fontSize="lg">
+            Управляйте QR-кодами и переводами с помощью современного интерфейса.
+          </Text>
+        </Stack>
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={10} mt={10}>
+          {features.map((item) => (
+            <Stack key={item.title} spacing={3} align="center" shadow="md" p={5} borderRadius="md">
+              <Image src={item.image} alt={item.title} boxSize="200px" objectFit="cover" borderRadius="md" />
+              <Heading size="md">{item.title}</Heading>
+              <Text>{item.description}</Text>
+            </Stack>
+          ))}
+        </SimpleGrid>
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable navigation bar with responsive button layout
- build home page with informative blocks and imagery
- route root path to new home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and unused vars)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895df19af348329a60e1a8969836bcb